### PR TITLE
make the simulation image resizable

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -10,5 +10,5 @@ img {
     overflow: hidden;
     line-height: 0;
     max-width: 100%;
-    max-height: 100vh;
+    width: 80%;
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,14 @@
+img {
+    width: 100%;
+    height: 100%;
+}
+
+.resizable {
+    display: inline-block;
+    background: grey;
+    resize: both;
+    overflow: hidden;
+    line-height: 0;
+    max-width: 100%;
+    max-height: 100vh;
+}


### PR DESCRIPTION
The image should be resizable to whatever you like by grabbing the bottom right corner.

@virgile-baudrot maybe check out this branch and see if you like this behavior. Just making it fit the screen is hard because I don't know what the dimensions will be, so I made it flexible.